### PR TITLE
Add Fortran as requirement

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -17,6 +17,5 @@ cmake -G Ninja ^
     -DCMAKE_INCLUDE_PATH:PATH="%LIBRARY_INC%" ^
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ^
     -Dpython_package=ON ^
-    -Dlanguage=Python ^
     ..
 ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,6 @@ cmake -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -Dpython_package=ON \
-    -Dlanguage=Python \
     -Dpython_version=$(python -c "import sys; print(str(sys.version_info[0])+'.'+str(sys.version_info[1])+'.'+str(sys.version_info[2]))") \
     ..
 # Build step

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
     - cmake >=3.13
     - make
     - ninja


### PR DESCRIPTION
This PR adds Fortran as a requirement, which is necessary for using Python drivers to control Fortran plugins.